### PR TITLE
fix #2 READMEにリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@
  1. Windowsであれば「**gradlew.bat**」Linuxであれば「**gradlew**」を実行し、gradle実行環境を作成する。
  1. プロジェクトのカレントディレクトリで`./gradlew build`コマンドを実行する。
  1. `build\libs`配下に「**jar**」が生成されます。
- 1. 「**jar**」を依存関係に追加しご使用ください。
+ 1. 「**jar**」を依存関係に追加し、ご使用ください。
  
+ ## 3.その他
+ 1. [Javadoc](https://r-fujiyama.github.io/dmm-java-sdk/)を用意していますので、是非ご参考ください。


### PR DESCRIPTION
### 対応内容
READMEにJavadocへのリンクを追加